### PR TITLE
Add support to skip starting tailscale on start up.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## 1.0.1 (2023-06-15)
+
+* Added ``TAILSCALE_BUILD_EXCLUDE_START_SCRIPT_FROM_PROFILE_D`` build environment variable
+  to control when the tailscale script starts.
+
 ## 1.0.1 (2023-06-13)
 
 * Updated default tailscale version from 1.40.0 to 1.42.0

--- a/README.md
+++ b/README.md
@@ -91,7 +91,15 @@ cause a rebuild. These are all optional and will default to the latest values.
 
 - ``TAILSCALE_BUILD_TS_VERSION`` - The target version Tailscale package.
 - ``TAILSCALE_BUILD_TS_TARGETARCH`` - The target architecture for the Tailscale package.
+- ``TAILSCALE_BUILD_EXCLUDE_START_SCRIPT_FROM_PROFILE_D`` - Excludes the start script from the
+  [buildpack's ``.profile.d/`` folder](https://devcenter.heroku.com/articles/buildpack-api#profile-d-scripts).
+  If you set this to true, you must call ``vendor/tailscale/heroku-tailscale-start.sh``. This likely should go
+  into your ``.profile`` script ([see Heroku docs](https://devcenter.heroku.com/articles/dynos#the-profile-file)).
+  Starting the script in your ``.profile`` file would allow you to better control environment
+  variables in respect to the executables. For example, a specific dyno could change
+  ``TAILSCALE_HOSTNAME`` before tailscale starts.
 - ``TAILSCALE_BUILD_PROXYCHAINS_REPO`` - The repository to install the proxychains-ng library from.
+
 
 ### Customizing proxychains.conf
 

--- a/bin/compile
+++ b/bin/compile
@@ -112,8 +112,11 @@ mkdir -p "$BUILD_DIR/vendor/proxychains-ng"
 cp -r "$BUILDPACK_DIR/conf" "$BUILD_DIR/vendor/proxychains-ng/conf"
 echo 'export PATH="/app/vendor/proxychains-ng/bin:$PATH"' >> $BUILD_DIR/.profile.d/heroku-tailscale-buildpack.sh 2>&1 | indent
 echo 'export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/app/vendor/proxychains-ng/lib";' >> $BUILD_DIR/.profile.d/heroku-tailscale-buildpack.sh 2>&1 | indent
-# Add the line to start tailscale to the end of the file
-echo "/app/vendor/tailscale/heroku-tailscale-start.sh" >> $BUILD_DIR/.profile.d/heroku-tailscale-buildpack.sh 2>&1 | indent
+
+if [[ "${TAILSCALE_BUILD_EXCLUDE_START_SCRIPT_FROM_PROFILE_D:-}" != "True" ]]; then
+  # Add the line to start tailscale to the end of the file
+  echo "/app/vendor/tailscale/heroku-tailscale-start.sh" >> $BUILD_DIR/.profile.d/heroku-tailscale-buildpack.sh 2>&1 | indent
+fi
 
 pushd $CACHED_BUILD_DIR/app > /dev/null
 cp -rv ./ $BUILD_DIR 2>&1 | indent


### PR DESCRIPTION
This is controlled with TAILSCALE_BUILD_EXCLUDE_START_SCRIPT_FROM_PROFILE_D.

The start up script would need to be written by the app developer and likely put in the .profile script.